### PR TITLE
Lop provided fonts in responses

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -115,8 +115,10 @@ const css = async function css(ctx, retryCount = 0) {
 			headersToCache['Last-Modified'] = result.headers.get('last-modified');
 		}
 
+		const typefaceList = Array.from(new Set(parsedCss.map(({fontFamily, fontWeight, fontStyle}) => `\t\t${fontFamily} ${fontWeight}${fontStyle !== 'normal' ? ` ${fontStyle}` : ''}`))).sort().join('\n');
+
 		// Add debugging params as comment
-		const cssToCache = `/*\nRequested query:\t${queryString}\nRequesting User-Agent:\t${userAgentString}\n*/\n\n${replacedCss}`;
+		const cssToCache = `/*\nRequested query:\t${queryString}\nRequesting User-Agent:\t${userAgentString}\nProvided fonts and typefaces in response:\n${typefaceList}\n*/\n\n${replacedCss}`;
 
 		respondWithCache(ctx, addToCache(cacheKey, headersToCache, cssToCache));
 	} catch (e) {

--- a/src/cssParser.js
+++ b/src/cssParser.js
@@ -25,7 +25,7 @@ module.exports = function parseCss(css) {
 	const lines = css.split('\n').map(e => e.trim());
 	const result = [];
 	let current = newCssItem();
-	for (i = 0; i < lines.length; i++) {
+	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
 		if (line.startsWith('/* ') && line.endsWith('*/')) {
 			// We just found the key!


### PR DESCRIPTION
![Screenshot 2021-02-03 at 11 27 02](https://user-images.githubusercontent.com/2778689/106733943-c37b1500-6612-11eb-8bd9-03142426e31f.png)

This logs the provided fonts and families in the response for a faster inspection