### PR TITLE
Support font kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The system is configured using environment variables.
 | Key | Description |
 |---|---|
 | `MAX_CSS_ENTRIES` | The maximum number of CSS entries to cache. _Default 10000._ |
-| `MAX_FONT_ENTRIES` | The maximum number of font entries to cache. _Default 1000._ |
+| `MAX_FONT_ENTRIES` | The maximum number of font entries to cache. _Default 1000._ The same number is used for font kits |
 | `CSS_CACHE_CONTROL` | The value of the `Cache-control` header for all CSS responses. If not set, the upstream value will be used. |
-| `FONT_CACHE_CONTROL` | The value of the `Cache-control` header for all font responses. If not set, the upstream value will be used. |
+| `FONT_CACHE_CONTROL` | The value of the `Cache-control` header for all font responses. If not set, the upstream value will be used. The same value is used for font kits |
 | `PUBLIC_URL` | Public URL of access the fonts. _Default `http://localhost:3000/font/`._ |
 
 In the URL you can specify the exact same parameters as Google Fonts.
@@ -33,6 +33,7 @@ One additional feature is available: by specifying a query param `noPush` the li
 You can request instance statistic from the following URLs:
 - `_stats/css`: Cache statistics for the CSS cache
 - `_stats/font`: Cache statistics for the font cache
+- `_stats/fontKit`: Cache statistics for the font cache
 - `_stats/memory`: Statistics about the instance memory usage
 
 ## Quick start

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const uuid = require("uuid");
 
 const css = require("./css");
 const font = require("./font");
+const fontKit = require("./fontKit");
 const log = require("./log");
 
 let shuttingDown = false;
@@ -33,9 +34,13 @@ server.use(
 );
 server.use(router.get("/css", (ctx) => css(ctx)));
 server.use(router.get("/font/*", (ctx) => font(ctx)));
+server.use(router.get("/fontKit/*", (ctx) => fontKit(ctx)));
 server.use(router.get("/_stats/css", (ctx) => css.stats(ctx, consulServiceId)));
 server.use(
   router.get("/_stats/font", (ctx) => font.stats(ctx, consulServiceId))
+);
+server.use(
+  router.get("/_stats/fontKit", (ctx) => fontKit.stats(ctx, consulServiceId))
 );
 server.use(
   router.get("/_stats/memory", (ctx) => {

--- a/src/respondWithCache.js
+++ b/src/respondWithCache.js
@@ -1,0 +1,10 @@
+const dates = require("./dates");
+
+module.exports = function respondWithCache(ctx, cached) {
+  Object.entries(cached.headers).forEach((e) => ctx.set(e[0], e[1]));
+  ctx.set("Expires", dates.oneYearInTheFuture());
+  // Setting the status explicitly is required as the body is just piped
+  ctx.status = 200;
+
+  ctx.body = cached.body;
+};


### PR DESCRIPTION
Font kits are groups of letters in fonts when a `?text=` query param is used for Google Fonts. These were neither correctly preloaded nor proxied

_Term is totally made up by me to distinguish between the two font caches_

