### PR TITLE
Make consul registration explicit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,13 @@ const fontKit = require("./fontKit");
 const log = require("./log");
 
 let shuttingDown = false;
-let registeredToConsul = false;
 let serverInstance;
 
 const server = new Koa();
 
 const consulServiceId = uuid.v4();
-const consulHost = process.env.CONSUL_HOST
-  ? process.env.CONSUL_HOST
-  : "localhost";
-const serviceHost = process.env.SERVICE_HOST
-  ? process.env.SERVICE_HOST
-  : "localdev.internal.magnet.me";
+const consulHost = process.env.CONSUL_HOST;
+const serviceHost = process.env.SERVICE_HOST;
 const port = Number(process.env.PORT) ? Number(process.env.PORT) : 3000;
 
 const ONE_MEGABYTE = 1024 * 1024;
@@ -80,7 +75,6 @@ const onReady = () => {
             "info",
             `Successfully registered with consul as '${consulServiceId}'`
           );
-          registeredToConsul = true;
         } else {
           log("error", `Could not register with consul. Error was ${err}.`);
           process.exit(1);
@@ -115,7 +109,7 @@ const shutdown = () => {
   shuttingDown = true;
   log("info", "Starting the shutdown process");
 
-  if (registeredToConsul) {
+  if (consulHost) {
     // IntelliJ does not allow the shutdown sequence to propagate, so deregistration does not fire
     consul({ host: consulHost }).agent.service.deregister(
       {


### PR DESCRIPTION
Prior to this PR, if no `CONSUL_HOST` or `SERVICE_HOST` environment variables were set, these would fallback to pre-defined values, and a registration with consul would be attempted. If that registration failed, the boot would continue normally

This could lead to a situation where these environment variables were set, so the operator required a registration, but the registration could fail due to local consul issues. The service however could continue to boot, with especially from a Docker level, no signs of problems.

Therefore https://github.com/rogierslag/font-cacher/commit/627bc3d04055de48094a118aa3f118ef0c5ed3e5 introduced a hard failure in case the registration failed, and the service would exit with a non-zero status.

Inadvertently this broke setup for those who [were not using consul altogether](https://github.com/rogierslag/font-cacher/issues/13) as the system fell back to the pre-defined values, attempted registration, and failed. To facilitate all flows, it's better to make the consul registration explicit altogether

Closes https://github.com/rogierslag/font-cacher/issues/13